### PR TITLE
Improve progress updates with SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A web application that allows users to easily convert HEIC images to the WebP fo
 
 - Simple and intuitive web interface
 - Batch conversion of multiple HEIC images
-- Real-time progress tracking
+- Real-time progress tracking using Server-Sent Events (SSE)
 - Automatic ZIP file handling for input and output
 - High-quality WebP conversion with optimized settings
 - Error handling for failed conversions

--- a/index.js
+++ b/index.js
@@ -1,28 +1,51 @@
 const express = require('express');
 const multer = require('multer');
 const unzipper = require('unzipper');
-const fs = require('fs');             // ✅ stream methods
-const fsp = require('fs/promises');   // ✅ promise-based methods
+const fs = require('fs'); // stream methods
+const fsp = require('fs/promises'); // promise-based methods
 const path = require('path');
 const sharp = require('sharp');
 const archiver = require('archiver');
 const heicConvert = require('heic-convert');
+const { EventEmitter } = require('events');
 
 const app = express();
 const PORT = 3000;
 
 const upload = multer({ dest: 'uploads/' });
 
+const progressEmitter = new EventEmitter();
+const sseClients = [];
+
 app.use(express.static('public'));
 
 let currentStatus = 'Idle';
 
-app.get('/progress', (req, res) => {
-  res.json({ status: currentStatus });
+app.get('/progress-sse', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  res.write(`data: ${JSON.stringify({ status: currentStatus })}\n\n`);
+  sseClients.push(res);
+
+  req.on('close', () => {
+    const index = sseClients.indexOf(res);
+    if (index !== -1) sseClients.splice(index, 1);
+  });
 });
+
+function broadcastStatus() {
+  const data = `data: ${JSON.stringify({ status: currentStatus })}\n\n`;
+  sseClients.forEach(client => client.write(data));
+}
+
+progressEmitter.on('update', broadcastStatus);
 
 app.post('/upload', upload.single('zipfile'), async (req, res) => {
   currentStatus = 'Extracting ZIP...';
+  progressEmitter.emit('update');
 
   const zipPath = req.file.path;
   const extractDir = `uploads/${req.file.filename}_extracted`;
@@ -44,10 +67,10 @@ app.post('/upload', upload.single('zipfile'), async (req, res) => {
   let completed = 0;
   for (const file of heicFiles) {
     currentStatus = `Converting ${++completed} of ${heicFiles.length}...`;
+    progressEmitter.emit('update');
     const inputPath = path.join(extractDir, file);
     const name = path.basename(file, '.heic');
 
-    // Add this around line 48 in index.js, inside the for loop
     try {
       const inputBuffer = await fsp.readFile(inputPath);
       const outputBuffer = await heicConvert({
@@ -60,12 +83,13 @@ app.post('/upload', upload.single('zipfile'), async (req, res) => {
         .toFile(path.join(outputDir, `${name}.webp`));
     } catch (error) {
       console.error(`Error converting ${file}: ${error.message}`);
-      // You could update status to show errors too
       currentStatus = `Error converting ${file}: ${error.message}`;
+      progressEmitter.emit('update');
     }
   }
 
   currentStatus = 'Creating ZIP...';
+  progressEmitter.emit('update');
 
   const archivePath = `uploads/${req.file.filename}_converted.zip`;
   const output = fs.createWriteStream(archivePath);
@@ -77,6 +101,7 @@ app.post('/upload', upload.single('zipfile'), async (req, res) => {
 
   output.on('close', () => {
     currentStatus = 'Done';
+    progressEmitter.emit('update');
     res.download(archivePath, 'converted_webp.zip');
   });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -70,34 +70,31 @@
       xhr.open('POST', '/upload', true);
       xhr.responseType = 'blob';
 
-      // Poll status
+      // Subscribe to progress updates using Server-Sent Events
       let progress = 10;
-      const interval = setInterval(async () => {
-        try {
-          const res = await fetch('/progress');
-          const { status } = await res.json();
-          statusText.textContent = status;
-          
-          if (status.includes('Converting')) {
-            const match = status.match(/Converting (\d+) of (\d+)/);
-            if (match) {
-              const [_, current, total] = match;
-              progress = 10 + Math.floor((current / total) * 70);
-            }
-          } else if (status.includes('Creating ZIP')) {
-            progress = 80;
-          } else if (status.includes('Done')) {
-            progress = 100;
+      const eventSource = new EventSource('/progress-sse');
+
+      eventSource.onmessage = (event) => {
+        const { status } = JSON.parse(event.data);
+        statusText.textContent = status;
+
+        if (status.includes('Converting')) {
+          const match = status.match(/Converting (\d+) of (\d+)/);
+          if (match) {
+            const [_, current, total] = match;
+            progress = 10 + Math.floor((current / total) * 70);
           }
-          
-          progressBar.style.width = `${progress}%`;
-        } catch (err) {
-          console.error('Error polling status:', err);
+        } else if (status.includes('Creating ZIP')) {
+          progress = 80;
+        } else if (status.includes('Done')) {
+          progress = 100;
         }
-      }, 1000);
+
+        progressBar.style.width = `${progress}%`;
+      };
 
       xhr.onload = function () {
-        clearInterval(interval);
+        eventSource.close();
         progress = 100;
         progressBar.style.width = '100%';
         
@@ -110,7 +107,7 @@
       };
 
       xhr.onerror = function() {
-        clearInterval(interval);
+        eventSource.close();
         statusText.textContent = 'Error occurred during conversion';
       };
 


### PR DESCRIPTION
## Summary
- use an EventEmitter and add `/progress-sse` endpoint for real-time status updates
- push progress updates from the server
- listen to progress on the client using `EventSource`
- update README feature list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6846e234dd1c83259be9790108cbb3c3